### PR TITLE
Simplify tabs: slide-out assumptions, reorganize content

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -65,6 +65,13 @@ svg .domain {
 	scrollbar-width: none;
 }
 
+/* Assumptions slide-out panel: push content left on large screens */
+@media (min-width: 1024px) {
+	.assumptions-open {
+		margin-right: 380px;
+	}
+}
+
 /* Area fill controlled via --chart-area-fill CSS variable on parent container */
 svg .path-area {
 	fill: var(--chart-area-fill, transparent) !important;

--- a/web/src/lib/components/CorporateView.svelte
+++ b/web/src/lib/components/CorporateView.svelte
@@ -1,14 +1,13 @@
 <script lang="ts">
-	import { amazonProjections, amazonDystopiaProjections, portfolioResult } from '$lib/stores/results';
+	import { amazonProjections, amazonDystopiaProjections } from '$lib/stores/results';
 	import { scenarioParams, activePreset } from '$lib/stores/scenario';
 	import { PRESETS, type PresetName } from '$lib/model/presets';
 	import { formatCompact, formatPct, formatNumber, formatCurrency } from '$lib/model/format';
 	import { PORTFOLIO_COMPANIES } from '$lib/model/companies';
 	import ProfitProjection from './ProfitProjection.svelte';
 	import TwoFutures from './TwoFutures.svelte';
-	import PortfolioIncome from './PortfolioIncome.svelte';
 	import WorkforceChart from './WorkforceChart.svelte';
-	import type { YearProjection, ScenarioParams, PortfolioResult as PortfolioResultType } from '$lib/model/types';
+	import type { YearProjection, ScenarioParams } from '$lib/model/types';
 
 	const amazon = PORTFOLIO_COMPANIES.find((c) => c.ticker === 'AMZN')!;
 	let currentParams = $state<ScenarioParams | null>(null);
@@ -18,15 +17,10 @@
 	});
 
 	let projections = $state<YearProjection[]>([]);
-	let portfolio = $state<PortfolioResultType | null>(null);
 	let preset = $state<PresetName>('moderate');
 
 	$effect(() => {
 		const unsub = amazonProjections.subscribe((v) => { projections = v; });
-		return unsub;
-	});
-	$effect(() => {
-		const unsub = portfolioResult.subscribe((v) => { portfolio = v; });
 		return unsub;
 	});
 	$effect(() => {
@@ -198,27 +192,6 @@
 		<WorkforceChart />
 		<ProfitProjection />
 		<TwoFutures />
-		<PortfolioIncome />
 	</div>
 
-	{#if portfolio}
-		<!-- Portfolio breakdown -->
-		<div class="bg-bg-card rounded-xl border border-bg-input p-3 sm:p-5 space-y-3">
-			<h3 class="font-semibold text-accent">10-Company Portfolio</h3>
-			<p class="text-xs text-text-muted mb-2">
-				Equal-weight allocation across sectors. Per $1M invested, year 15 total income:
-			</p>
-			<div class="grid grid-cols-2 md:grid-cols-5 gap-2 text-xs">
-				{#each portfolio.allocations as alloc}
-					{@const yr15 = portfolio.yearlyResults[15]}
-					{@const div = yr15?.companyDividends[alloc.company.ticker] ?? 0}
-					<div class="bg-bg/50 rounded p-2">
-						<div class="font-semibold text-text">{alloc.company.ticker}</div>
-						<div class="text-text-muted">{alloc.company.name}</div>
-						<div class="font-mono text-accent">{formatCompact(div)}/yr</div>
-					</div>
-				{/each}
-			</div>
-		</div>
-	{/if}
 </div>

--- a/web/src/lib/components/FAQ.svelte
+++ b/web/src/lib/components/FAQ.svelte
@@ -137,31 +137,6 @@
 			]
 		},
 		{
-			category: 'Baby Born Today',
-			items: [
-				{
-					q: 'Why a birth grant instead of monthly contributions?',
-					a: 'Compound growth is exponential — the earlier money enters the market, the more it multiplies. A $50k lump sum at birth has 21 years to compound before the child turns 21. Monthly contributions starting later miss the most powerful compounding years. The model shows this clearly: a birth grant of $50k can grow to several hundred thousand by age 21, while reaching the same amount through monthly savings starting at age 22 requires dramatically higher contributions.'
-				},
-				{
-					q: 'Where does the cost-of-living reduction come from?',
-					a: 'The supply chain cascade. As AI automates not just individual companies but their entire supply chains — shipping, manufacturing, agriculture, energy — the cost of producing everything drops. A baby born today will enter adulthood in a world where $75k of purchasing power might only cost $45k-$55k in nominal terms. The model tracks this using the same S-curve as workforce displacement, applied to non-labor costs across the economy.'
-				},
-				{
-					q: 'Is $50k per baby realistic as government policy?',
-					a: 'About 3.6 million babies are born in the US each year. At $50k each, that\'s $180 billion/year — roughly 3% of the federal budget. For context, the US spends ~$900B/year on defense. Whether it\'s politically feasible is a different question, but the math isn\'t absurd. And if the alternative is supporting those same people with $25k/year safety net spending for decades, the birth grant is dramatically cheaper.'
-				},
-				{
-					q: 'What happens if the market crashes during those 21 years?',
-					a: 'The model uses portfolio growth rates derived from the scenario engine, which includes demand feedback effects. In moderate scenarios, growth is strong because AI-boosted profits drive returns. In extreme scenarios with low investor adoption, demand collapse drags down returns. Real markets would also have volatility the model doesn\'t capture. But over 21-year horizons, equities have historically recovered from every crash. The 4% SWR rule already accounts for sequence-of-returns risk.'
-				},
-				{
-					q: 'Why age 21 as the unlock age?',
-					a: 'It\'s a balance. Younger unlock ages (18) risk the money being spent before the person understands its purpose. Older ages (25, 30) mean the person has years without access during peak displacement. Age 21 gives 21 years of compounding and unlocks right around when most people are establishing financial independence. The model could work with other unlock ages — the compound math just shifts.'
-				}
-			]
-		},
-		{
 			category: 'Taxation & Government',
 			items: [
 				{

--- a/web/src/lib/components/Hero.svelte
+++ b/web/src/lib/components/Hero.svelte
@@ -84,6 +84,6 @@
 	</div>
 
 	<p class="text-sm text-text-muted mt-4">
-		Curious to learn more? Check out our <a href="/faq" class="text-accent hover:text-accent-hover underline underline-offset-2">FAQ</a>.
+		Curious to learn more? Check out our <a href="{base}/faq" class="text-accent hover:text-accent-hover underline underline-offset-2">FAQ</a>.
 	</p>
 </section>

--- a/web/src/lib/components/Hero.svelte
+++ b/web/src/lib/components/Hero.svelte
@@ -82,4 +82,8 @@
 		</button>
 		<span class="text-xs text-text-muted uppercase tracking-wide">...or the hope.</span>
 	</div>
+
+	<p class="text-sm text-text-muted mt-4">
+		Curious to learn more? Check out our <a href="/faq" class="text-accent hover:text-accent-hover underline underline-offset-2">FAQ</a>.
+	</p>
 </section>

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -9,22 +9,45 @@
 	import IncomeReplacement from '$lib/components/IncomeReplacement.svelte';
 	import PortfolioGrowth from '$lib/components/PortfolioGrowth.svelte';
 	import GapAnalysis from '$lib/components/GapAnalysis.svelte';
+	import PortfolioIncome from '$lib/components/PortfolioIncome.svelte';
 	import KeyMetrics from '$lib/components/KeyMetrics.svelte';
 	import CorporateView from '$lib/components/CorporateView.svelte';
 	import CompanyExplorer from '$lib/components/CompanyExplorer.svelte';
-	import BabyBornToday from '$lib/components/BabyBornToday.svelte';
 	import FiscalImpact from '$lib/components/FiscalImpact.svelte';
 	import AIProviders from '$lib/components/AIProviders.svelte';
-	import FAQ from '$lib/components/FAQ.svelte';
 	import Footer from '$lib/components/Footer.svelte';
 	import { personalInputs } from '$lib/stores/personal';
 	import { scenarioParams, activePreset } from '$lib/stores/scenario';
+	import { portfolioResult } from '$lib/stores/results';
+	import { formatCompact } from '$lib/model/format';
+	import type { PortfolioResult as PortfolioResultType } from '$lib/model/types';
 	import { decodeUrlState } from '$lib/utils/url-state';
 	import { onMount } from 'svelte';
 	import { PRESETS, type PresetName } from '$lib/model/presets';
 	import { browser } from '$app/environment';
+	import { fly } from 'svelte/transition';
 
-	let activeTab = $state<'corporate' | 'personal' | 'explore' | 'baby' | 'fiscal' | 'providers' | 'assumptions' | 'faq'>('corporate');
+	let activeTab = $state<'corporate' | 'personal' | 'explore' | 'fiscal' | 'providers'>('corporate');
+	let showAssumptions = $state(false);
+	let portfolio = $state<PortfolioResultType | null>(null);
+
+	$effect(() => {
+		const unsub = portfolioResult.subscribe((v) => { portfolio = v; });
+		return unsub;
+	});
+
+	// Lock body scroll on mobile when assumptions panel is open
+	$effect(() => {
+		if (!browser) return;
+		if (showAssumptions && window.innerWidth < 640) {
+			document.body.style.overflow = 'hidden';
+		} else {
+			document.body.style.overflow = '';
+		}
+		return () => {
+			document.body.style.overflow = '';
+		};
+	});
 
 	onMount(() => {
 		if (!browser) return;
@@ -48,7 +71,7 @@
 	</div>
 
 	<!-- Tab navigation -->
-	<div class="max-w-7xl mx-auto px-4">
+	<div class="max-w-7xl mx-auto px-4 transition-all duration-300 {showAssumptions ? 'assumptions-open' : ''}">
 		<div role="tablist" class="flex gap-1 border-b border-bg-input mb-6 overflow-x-auto scrollbar-hide">
 			<button
 				role="tab"
@@ -106,42 +129,22 @@
 				AI Providers
 			</button>
 			<button
-				role="tab"
-				aria-selected={activeTab === 'baby'}
-				aria-controls="panel-baby"
-				onclick={() => (activeTab = 'baby')}
-				class="whitespace-nowrap flex-shrink-0 px-3 py-2.5 md:px-5 md:py-3 text-sm font-medium transition-colors border-b-2 {activeTab === 'baby'
+				aria-label="Toggle assumptions panel"
+				aria-expanded={showAssumptions}
+				onclick={() => (showAssumptions = !showAssumptions)}
+				class="ml-auto flex-shrink-0 px-3 py-2.5 md:px-4 md:py-3 transition-colors border-b-2 {showAssumptions
 					? 'border-accent text-accent'
 					: 'border-transparent text-text-muted hover:text-text'}"
 			>
-				Baby Born Today
-			</button>
-			<button
-				role="tab"
-				aria-selected={activeTab === 'assumptions'}
-				aria-controls="panel-assumptions"
-				onclick={() => (activeTab = 'assumptions')}
-				class="whitespace-nowrap flex-shrink-0 px-3 py-2.5 md:px-5 md:py-3 text-sm font-medium transition-colors border-b-2 {activeTab === 'assumptions'
-					? 'border-accent text-accent'
-					: 'border-transparent text-text-muted hover:text-text'}"
-			>
-				Assumptions
-			</button>
-			<button
-				role="tab"
-				aria-selected={activeTab === 'faq'}
-				aria-controls="panel-faq"
-				onclick={() => (activeTab = 'faq')}
-				class="whitespace-nowrap flex-shrink-0 px-3 py-2.5 md:px-5 md:py-3 text-sm font-medium transition-colors border-b-2 {activeTab === 'faq'
-					? 'border-accent text-accent'
-					: 'border-transparent text-text-muted hover:text-text'}"
-			>
-				FAQ
+				<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+					<circle cx="12" cy="12" r="3"></circle>
+					<path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
+				</svg>
 			</button>
 		</div>
 	</div>
 
-	<main class="max-w-7xl mx-auto px-4 pb-12">
+	<main class="max-w-7xl mx-auto px-4 pb-12 transition-all duration-300 {showAssumptions ? 'assumptions-open' : ''}">
 		{#if activeTab === 'personal'}
 			<div id="panel-personal" role="tabpanel">
 				<!-- Key metrics bar -->
@@ -160,6 +163,26 @@
 						<PersonalTimeline />
 						<IncomeReplacement />
 						<PortfolioGrowth />
+						<PortfolioIncome />
+						{#if portfolio}
+							<div class="bg-bg-card rounded-xl border border-bg-input p-3 sm:p-5 space-y-3">
+								<h3 class="font-semibold text-accent">10-Company Portfolio</h3>
+								<p class="text-xs text-text-muted mb-2">
+									Equal-weight allocation across sectors. Per $1M invested, year 15 total income:
+								</p>
+								<div class="grid grid-cols-2 md:grid-cols-5 gap-2 text-xs">
+									{#each portfolio.allocations as alloc}
+										{@const yr15 = portfolio.yearlyResults[15]}
+										{@const div = yr15?.companyDividends[alloc.company.ticker] ?? 0}
+										<div class="bg-bg/50 rounded p-2">
+											<div class="font-semibold text-text">{alloc.company.ticker}</div>
+											<div class="text-text-muted">{alloc.company.name}</div>
+											<div class="font-mono text-accent">{formatCompact(div)}/yr</div>
+										</div>
+									{/each}
+								</div>
+							</div>
+						{/if}
 						<ScenarioCompare />
 						<GapAnalysis />
 					</div>
@@ -169,12 +192,6 @@
 			<div id="panel-explore" role="tabpanel">
 				<div class="max-w-5xl mx-auto">
 					<CompanyExplorer />
-				</div>
-			</div>
-		{:else if activeTab === 'baby'}
-			<div id="panel-baby" role="tabpanel">
-				<div class="max-w-5xl mx-auto">
-					<BabyBornToday />
 				</div>
 			</div>
 		{:else if activeTab === 'fiscal'}
@@ -189,18 +206,6 @@
 					<AIProviders />
 				</div>
 			</div>
-		{:else if activeTab === 'faq'}
-			<div id="panel-faq" role="tabpanel">
-				<div class="max-w-3xl mx-auto">
-					<FAQ />
-				</div>
-			</div>
-		{:else if activeTab === 'assumptions'}
-			<div id="panel-assumptions" role="tabpanel">
-				<div class="max-w-3xl mx-auto space-y-6">
-					<AdvancedControls />
-				</div>
-			</div>
 		{:else}
 			<div id="panel-corporate" role="tabpanel">
 				<div class="max-w-5xl mx-auto">
@@ -209,6 +214,42 @@
 			</div>
 		{/if}
 	</main>
+
+	<!-- Assumptions slide-out panel -->
+	{#if showAssumptions}
+		<!-- Mobile backdrop -->
+		<button
+			class="fixed inset-0 bg-black/50 z-30 sm:hidden"
+			onclick={() => (showAssumptions = false)}
+			aria-label="Close assumptions panel"
+			tabindex="-1"
+		></button>
+
+		<aside
+			class="fixed top-0 right-0 h-full w-full sm:w-[380px] bg-bg border-l border-bg-input z-40 flex flex-col shadow-2xl"
+			transition:fly={{ x: 380, duration: 250 }}
+		>
+			<!-- Header -->
+			<div class="flex items-center justify-between px-4 py-3 border-b border-bg-input">
+				<h2 class="text-lg font-semibold text-text">Assumptions</h2>
+				<button
+					onclick={() => (showAssumptions = false)}
+					aria-label="Close assumptions panel"
+					class="p-1.5 rounded-md text-text-muted hover:text-text hover:bg-bg-input transition-colors"
+				>
+					<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+						<line x1="18" y1="6" x2="6" y2="18"></line>
+						<line x1="6" y1="6" x2="18" y2="18"></line>
+					</svg>
+				</button>
+			</div>
+
+			<!-- Scrollable body -->
+			<div class="flex-1 overflow-y-auto px-4 py-4">
+				<AdvancedControls />
+			</div>
+		</aside>
+	{/if}
 
 	<Footer />
 </div>

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -36,10 +36,10 @@
 		return unsub;
 	});
 
-	// Lock body scroll on mobile when assumptions panel is open
+	// Lock body scroll below lg breakpoint when assumptions panel is open
 	$effect(() => {
 		if (!browser) return;
-		if (showAssumptions && window.innerWidth < 640) {
+		if (showAssumptions && window.innerWidth < 1024) {
 			document.body.style.overflow = 'hidden';
 		} else {
 			document.body.style.overflow = '';
@@ -61,6 +61,8 @@
 		}
 	});
 </script>
+
+<svelte:window onkeydown={(e) => e.key === 'Escape' && showAssumptions && (showAssumptions = false)} />
 
 <div class="min-h-screen bg-bg">
 	<Hero />

--- a/web/src/routes/faq/+page.svelte
+++ b/web/src/routes/faq/+page.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	import FAQ from '$lib/components/FAQ.svelte';
+	import Footer from '$lib/components/Footer.svelte';
+	import { base } from '$app/paths';
+</script>
+
+<nav class="sticky top-0 z-40 bg-bg/95 backdrop-blur border-b border-bg-input">
+	<div class="max-w-3xl mx-auto px-4 py-3 flex items-center gap-3">
+		<a
+			href="{base}/"
+			class="flex items-center gap-1.5 text-sm text-text-muted hover:text-accent transition-colors"
+		>
+			<svg viewBox="0 0 24 24" class="w-4 h-4 fill-none stroke-current" stroke-width="2">
+				<polyline points="15 18 9 12 15 6" />
+			</svg>
+			Home
+		</a>
+	</div>
+</nav>
+
+<main class="max-w-3xl mx-auto px-4 py-8">
+	<FAQ />
+</main>
+
+<Footer />


### PR DESCRIPTION
## Summary
- Replace Assumptions tab with a gear icon that opens a slide-out panel from the right (380px desktop, full-width overlay on mobile). Panel stays open across tab switches so users can tweak parameters while viewing any content tab.
- Move PortfolioIncome chart and 10-company portfolio grid from the Amazon tab to Your Outlook, keeping the Amazon tab focused on the single-company story.
- Remove Baby Born Today and FAQ from the tab bar. FAQ is now a dedicated `/faq` route linked from the Hero section.
- Clean up unused imports and dead code in CorporateView.

## Test plan
- [ ] Gear icon visible at right end of tab bar
- [ ] Click gear → panel slides in from right with animation
- [ ] Panel stays open while switching between content tabs
- [ ] Desktop: main content shrinks to make room (no overlap)
- [ ] Mobile: full-width overlay with backdrop, body scroll locked
- [ ] Click X, backdrop, or gear again → panel closes
- [ ] Sliders in panel update charts live on whichever tab is active
- [ ] PortfolioIncome chart and 10-company grid appear in Your Outlook
- [ ] Amazon tab no longer shows portfolio chart or grid
- [ ] /faq route works with Home back link
- [ ] `npm run build` succeeds, 86 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)