### PR TITLE
Add /faq to sitemap for Google indexing

### DIFF
--- a/web/static/sitemap.xml
+++ b/web/static/sitemap.xml
@@ -1,8 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Hand-maintained. adapter-static copies this verbatim; add an entry for every new route. -->
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://arewescrewed.ai/</loc>
+    <lastmod>2026-07-08</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://arewescrewed.ai/faq</loc>
+    <lastmod>2026-07-08</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary
The static sitemap (`web/static/sitemap.xml`) only listed the homepage `/`, so the `/faq` route was invisible to Google. This adds the `/faq` entry plus `lastmod` timestamps, and a comment noting the file is hand-maintained (adapter-static copies it verbatim — new routes must be added manually).

## After merge / deploy
1. Confirm `https://arewescrewed.ai/sitemap.xml` shows both URLs once the site rebuilds.
2. In Google Search Console (arewescrewed.ai property) → Sitemaps → submit `sitemap.xml` (one-time; Google re-crawls automatically after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)