### PR TITLE
Fix per-page canonical/og:url so /faq indexes

### DIFF
--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -1,7 +1,13 @@
 <script lang="ts">
 	import '../app.css';
+	import { page } from '$app/state';
 
 	let { children } = $props();
+
+	const SITE = 'https://arewescrewed.ai';
+	// Per-page canonical/og:url so each route (e.g. /faq) is indexed on its own,
+	// not collapsed into the homepage. pathname is '/' at root, '/faq' on the FAQ page.
+	let pageUrl = $derived(SITE + page.url.pathname);
 </script>
 
 <svelte:head>
@@ -9,14 +15,14 @@
 	<meta name="description" content="AI is replacing jobs. Can you survive as an investor? Calculate your personal outlook under different AI automation scenarios." />
 
 	<!-- Canonical -->
-	<link rel="canonical" href="https://arewescrewed.ai" />
+	<link rel="canonical" href={pageUrl} />
 
 	<!-- Open Graph -->
 	<meta property="og:type" content="website" />
 	<meta property="og:site_name" content="Are We Screwed?" />
 	<meta property="og:title" content="Are We Screwed? — AI Displacement Financial Calculator" />
 	<meta property="og:description" content="AI is replacing jobs. Can you survive as an investor? Calculate your personal outlook under different AI automation scenarios." />
-	<meta property="og:url" content="https://arewescrewed.ai" />
+	<meta property="og:url" content={pageUrl} />
 	<meta property="og:image" content="https://arewescrewed.ai/og-image.jpg?v=2" />
 	<meta property="og:image:width" content="1200" />
 	<meta property="og:image:height" content="630" />


### PR DESCRIPTION
## Problem
Google Search Console flagged indexing issues. Root cause: the canonical link and `og:url` were hardcoded to `https://arewescrewed.ai` in `+layout.svelte`, so **every** page — including `/faq` — declared the homepage as its canonical. Google collapses `/faq` into the homepage and won't index it separately, undercutting the sitemap entry added in #13.

Note: the separate "Page with redirect" GSC notice is caused by the intentional `www`→apex and `http`→`https` 301s. Those are correct canonicalization and were left untouched.

## Fix
Derive `canonical` and `og:url` from `page.url.pathname` (`$app/state`), so each route gets its own URL.

Verified in the prerendered build:
- `/` → `https://arewescrewed.ai/`
- `/faq` → `https://arewescrewed.ai/faq`

Both match the sitemap. All 92 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)